### PR TITLE
3A-G03-W010-PR01. Refactor of Ambiguous e Parameter

### DIFF
--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -197,7 +197,7 @@ export default function ReportsPage() {
               <select
                 className="select select-bordered w-full"
                 value={reportType}
-                onChange={(e) => setReportType(e.target.value as ReportType)}
+                onChange={(event) => setReportType(event.target.value as ReportType)}
               >
                 {REPORT_TYPE_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -224,10 +224,10 @@ export default function ReportsPage() {
                       type="date"
                       className="input input-bordered w-full"
                       value={customRange.from}
-                      onChange={(e) =>
+                      onChange={(event) =>
                         setCustomRange((current) => ({
                           ...current,
-                          from: e.target.value,
+                          from: event.target.value,
                         }))
                       }
                     />
@@ -242,10 +242,10 @@ export default function ReportsPage() {
                       type="date"
                       className="input input-bordered w-full"
                       value={customRange.to}
-                      onChange={(e) =>
+                      onChange={(event) =>
                         setCustomRange((current) => ({
                           ...current,
-                          to: e.target.value,
+                          to: event.target.value,
                         }))
                       }
                     />
@@ -262,8 +262,8 @@ export default function ReportsPage() {
                 <select
                   className="select select-bordered w-full"
                   value={dateRange}
-                  onChange={(e) =>
-                    setDateRange(e.target.value as DateRangeOption)
+                  onChange={(event) =>
+                    setDateRange(event.target.value as DateRangeOption)
                   }
                 >
                   {RANGE_OPTIONS.map((option) => (

--- a/app/api/reports/[id]/download/route.ts
+++ b/app/api/reports/[id]/download/route.ts
@@ -91,8 +91,8 @@ export async function GET(
         '--- FLUSH EVENTS ---',
         'id,deviceId,waterVolume,duration,timestamp',
         ...flushEvents.map(
-          (e) =>
-            `${e.id},${e.deviceId},${e.waterVolume},${e.duration},${e.timestamp.toDate().toISOString()}`,
+          (event) =>
+            `${event.id},${event.deviceId},${event.waterVolume},${event.duration},${event.timestamp.toDate().toISOString()}`,
         ),
         '',
         '--- UV CYCLES ---',
@@ -113,7 +113,7 @@ export async function GET(
     // ── JSON ───────────────────────────────────────────────────────────────────
     if (meta.format === 'json') {
       const totalWater = flushEvents.reduce(
-        (s, e) => s + (e.waterVolume ?? 0),
+        (s, event) => s + (event.waterVolume ?? 0),
         0,
       );
       const uvCompleted = uvCycles.filter((c) => c.completed).length;
@@ -127,9 +127,9 @@ export async function GET(
               ? 100
               : Math.round((uvCompleted / uvCycles.length) * 10000) / 100,
         },
-        flushEvents: flushEvents.map((e) => ({
-          ...e,
-          timestamp: e.timestamp.toDate().toISOString(),
+        flushEvents: flushEvents.map((event) => ({
+          ...event,
+          timestamp: event.timestamp.toDate().toISOString(),
         })),
         uvCycles: uvCycles.map((c) => ({
           ...c,
@@ -147,12 +147,12 @@ export async function GET(
     // ── PDF ────────────────────────────────────────────────────────────────────
     const { generatePDFBuffer } = await import('@/lib/pdf-report');
 
-    const flushRows: FlushEventRow[] = flushEvents.map((e) => ({
-      id: e.id,
-      deviceId: e.deviceId,
-      waterVolume: e.waterVolume,
-      duration: e.duration,
-      timestamp: e.timestamp.toDate().toISOString(),
+    const flushRows: FlushEventRow[] = flushEvents.map((event) => ({
+      id: event.id,
+      deviceId: event.deviceId,
+      waterVolume: event.waterVolume,
+      duration: event.duration,
+      timestamp: event.timestamp.toDate().toISOString(),
     }));
 
     const uvRows: UVCycleRow[] = uvCycles.map((c) => ({

--- a/app/api/reports/generate/route.ts
+++ b/app/api/reports/generate/route.ts
@@ -95,7 +95,7 @@ function buildCSV(
 }
 
 function buildJSON(flushEvents: FlushEventDoc[], uvCycles: UVCycleDoc[]) {
-  const totalWater = flushEvents.reduce((s, e) => s + (e.waterVolume ?? 0), 0);
+  const totalWater = flushEvents.reduce((s, event) => s + (event.waterVolume ?? 0), 0);
   const uvCompleted = uvCycles.filter((c) => c.completed).length;
 
   return {
@@ -108,9 +108,9 @@ function buildJSON(flushEvents: FlushEventDoc[], uvCycles: UVCycleDoc[]) {
           ? 100
           : Math.round((uvCompleted / uvCycles.length) * 10000) / 100,
     },
-    flushEvents: flushEvents.map((e) => ({
-      ...e,
-      timestamp: e.timestamp.toDate().toISOString(),
+    flushEvents: flushEvents.map((event) => ({
+      ...event,
+      timestamp: event.timestamp.toDate().toISOString(),
     })),
     uvCycles: uvCycles.map((c) => ({
       ...c,
@@ -205,12 +205,12 @@ export async function POST(request: Request): Promise<NextResponse | Response> {
     // PDF — delegate to shared tsx helper (no JSX in .ts files)
     const { generatePDFBuffer } = await import('@/lib/pdf-report');
 
-    const flushRows: FlushEventRow[] = flushEvents.map((e) => ({
-      id: e.id,
-      deviceId: e.deviceId,
-      waterVolume: e.waterVolume,
-      duration: e.duration,
-      timestamp: e.timestamp.toDate().toISOString(),
+    const flushRows: FlushEventRow[] = flushEvents.map((event) => ({
+      id: event.id,
+      deviceId: event.deviceId,
+      waterVolume: event.waterVolume,
+      duration: event.duration,
+      timestamp: event.timestamp.toDate().toISOString(),
     }));
 
     const uvRows: UVCycleRow[] = uvCycles.map((c) => ({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
                 try {
                   var theme = localStorage.getItem('theme') || 'light';
                   document.documentElement.setAttribute('data-theme', theme);
-                } catch(e) {}
+                } catch(error) {}
               })();
             `,
           }}


### PR DESCRIPTION
## Summary
- **What does this change?** Renamed the `e` parameter to either `error` or `event` across the codebase depending on its context.
- **Why is it needed?** This improves the readability of the existing code by making variable names more descriptive, as specified in the issue.

## Changes
- Renamed `e` to `error` in `catch` blocks (e.g., `app/layout.tsx`).
- Renamed `e` to `event` for DOM event handlers (e.g., `app/(dashboard)/reports/page.tsx`).
- Renamed `e` to `event` in array map and reduce functions handling event data elements (e.g., in `app/api/reports/[id]/download/route.ts` and `app/api/reports/generate/route.ts`).

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.
