### PR TITLE
3A-G03-W003-PR01. Removal of Unused Imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,19 @@ import nextTs from 'eslint-config-next/typescript';
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
   globalIgnores([
     '.next/**',
     'out/**',


### PR DESCRIPTION
## Summary
This pull request enforces removal of unused imports and unused variables through ESLint.

## Changes Made
- enabled `@typescript-eslint/no-unused-vars`
- disabled the base `no-unused-vars` rule to avoid overlap
- allowed underscore-prefixed unused args/vars when intentionally ignored

## Verification
- `npm run lint`
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
